### PR TITLE
Fase 1: Presença RPC-only no fluxo de sessões

### DIFF
--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -130,10 +130,10 @@ export async function updateBookingAttendance(
   bookingId: string,
   attendanceConfirmed: boolean,
 ): Promise<void> {
-  const { error } = await supabase
-    .from("bookings")
-    .update({ attendance_confirmed: attendanceConfirmed })
-    .eq("id", bookingId);
+  const { error } = await supabase.rpc("set_booking_attendance", {
+    p_booking_id: bookingId,
+    p_attendance_confirmed: attendanceConfirmed,
+  });
   if (error) throw error;
 }
 


### PR DESCRIPTION
## Objetivo\nPadronizar atualização de presença para RPC-only, eliminando write direto no frontend para manter o pipeline DB-first.\n\n## Mudanças\n- src/services/sessions.ts\n  - updateBookingAttendance agora usa rpc('set_booking_attendance')\n\n## Critérios atendidos\n- [x] Nenhum update direto de presença no frontend\n- [x] Fluxo de presença mantido com validação central no banco\n\n## Validação\n- [x] npx tsc --noEmit