### PR TITLE
Fase 2: Reagendamento com elegibilidade central no banco

### DIFF
--- a/src/components/RescheduleDrawer.tsx
+++ b/src/components/RescheduleDrawer.tsx
@@ -11,6 +11,30 @@ import { formatSessionPeriod } from "@/utils/booking";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
+function getSwapErrorMessage(error: unknown): string {
+  const raw =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  const message = raw.toLowerCase();
+
+  if (message.includes("ja existe solicitacao pendente")) {
+    return "Já existe uma solicitação pendente para este agendamento.";
+  }
+  if (
+    message.includes("reagendamento disponivel apenas para inapto ou falta")
+  ) {
+    return "Reagendamento disponível apenas para militar inapto ou com falta registrada.";
+  }
+  if (message.includes("nova sessao nao encontrada")) {
+    return "Sessão de destino inválida. Selecione outra opção.";
+  }
+
+  return "Falha ao enviar solicitação";
+}
+
 interface Props {
   bookingId: string;
   currentDate: string;
@@ -96,7 +120,7 @@ export default function RescheduleDrawer({
       onClose();
     } catch (err) {
       console.error(err);
-      toast.error("Falha ao enviar solicitação");
+      toast.error(getSwapErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/services/bookings.ts
+++ b/src/services/bookings.ts
@@ -103,23 +103,17 @@ export async function createSwapRequest(params: SwapRequestParams) {
     attachmentUrl = urlData.publicUrl;
   }
 
-  type SwapInsertStrict =
-    Database["public"]["Tables"]["swap_requests"]["Insert"];
-
-  const payload: SwapInsertStrict = {
-    booking_id: params.bookingId,
-    requested_by: params.requestedBy,
-    new_session_id: params.newSessionId,
-    reason: JSON.stringify({
-      text: params.reasonText,
-      new_date: params.newDate,
-      attachment_url: attachmentUrl,
-    }),
-  };
-
-  const { data, error } = await supabase
-    .from("swap_requests")
-    .insert([payload]);
+  const { data, error } = await supabase.rpc(
+    "create_swap_request_if_eligible",
+    {
+      p_booking_id: params.bookingId,
+      p_requested_by: params.requestedBy,
+      p_new_session_id: params.newSessionId,
+      p_reason_text: params.reasonText,
+      p_new_date: params.newDate,
+      p_attachment_url: attachmentUrl,
+    },
+  );
   if (error) throw error;
   return data;
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -465,6 +465,17 @@ export interface Database {
         Args: { p_request_id: string; p_admin_id: string };
         Returns: { success: boolean; error: string }[];
       };
+      create_swap_request_if_eligible: {
+        Args: {
+          p_booking_id: string;
+          p_requested_by: string;
+          p_new_session_id: string;
+          p_reason_text: string;
+          p_new_date?: string | null;
+          p_attachment_url?: string | null;
+        };
+        Returns: string;
+      };
       get_results_history: {
         Args: {
           p_limit: number;
@@ -476,6 +487,10 @@ export interface Database {
       };
       set_booking_result: {
         Args: { p_booking_id: string; p_result: string };
+        Returns: undefined;
+      };
+      set_booking_attendance: {
+        Args: { p_booking_id: string; p_attendance_confirmed: boolean };
         Returns: undefined;
       };
     };


### PR DESCRIPTION
## Objetivo\nCentralizar criação de reagendamento no banco via RPC de elegibilidade e melhorar feedback de erro no fluxo de solicitação.\n\n## Mudanças\n- src/services/bookings.ts\n  - createSwapRequest agora usa rpc('create_swap_request_if_eligible')\n- src/components/RescheduleDrawer.tsx\n  - mapeamento de erros de negócio para mensagens claras no toast\n\n## Critérios atendidos\n- [x] Criação de swap ocorre via RPC\n- [x] UI exibe mensagens de elegibilidade compreensíveis\n\n## Validação\n- [x] npx tsc --noEmit