### PR TITLE
feat: auditoria estruturada com taxonomia administrativa (Sprint 3)

### DIFF
--- a/src/hooks/useSystemSettings.ts
+++ b/src/hooks/useSystemSettings.ts
@@ -8,6 +8,9 @@
 import supabase from "@/services/supabase";
 import type { AuditLogRow, SystemSettingsRow } from "@/types";
 
+export type StructuredAuditLogRow =
+  import("@/types/database.types").Database["public"]["Functions"]["get_audit_logs_structured"]["Returns"][number];
+
 export async function fetchSystemSettings(): Promise<SystemSettingsRow | null> {
   const { data, error } = await supabase
     .from("system_settings")
@@ -44,4 +47,14 @@ export async function fetchFullAuditLog(limit = 500): Promise<AuditLogRow[]> {
     .limit(limit);
   if (error) throw error;
   return (data as AuditLogRow[] | null) ?? [];
+}
+
+export async function fetchStructuredAuditLog(
+  limit = 500,
+): Promise<StructuredAuditLogRow[]> {
+  const { data, error } = await supabase.rpc("get_audit_logs_structured", {
+    p_limit: limit,
+  });
+  if (error) throw error;
+  return (data as StructuredAuditLogRow[] | null) ?? [];
 }

--- a/src/pages/AuditLog.tsx
+++ b/src/pages/AuditLog.tsx
@@ -8,7 +8,10 @@ import FullPageLoading from "@/components/FullPageLoading";
 import StatCard from "@/components/atomic/StatCard";
 import Layout from "@/components/layout/Layout";
 import useResponsive from "@/hooks/useResponsive";
-import { fetchFullAuditLog } from "@/hooks/useSystemSettings";
+import {
+  fetchStructuredAuditLog,
+  type StructuredAuditLogRow,
+} from "@/hooks/useSystemSettings";
 import {
   AlertTriangle,
   ChevronLeft,
@@ -24,22 +27,15 @@ import {
   Trash2,
   X,
 } from "@/icons";
-import type { AuditLogRow as DBAuditLogRow } from "@/types";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-type AuditLogRow = DBAuditLogRow;
+type AuditLogRow = StructuredAuditLogRow;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function extractIp(details: string | null | undefined): string {
-  try {
-    if (!details) return "-";
-    const obj = JSON.parse(details) as Record<string, unknown>;
-    return typeof obj.ip === "string" ? obj.ip : "-";
-  } catch {
-    return "-";
-  }
+function extractIp(record: AuditLogRow): string {
+  return record.ip_address ?? "-";
 }
 
 function formatJson(raw: string): string {
@@ -50,9 +46,17 @@ function formatJson(raw: string): string {
   }
 }
 
+function getDetailsPreview(record: AuditLogRow): string {
+  if (record.details_json) {
+    return JSON.stringify(record.details_json);
+  }
+
+  return record.details_text ?? "{}";
+}
+
 function ActionBadge({ action }: { action: string | null | undefined }) {
   const a = (action ?? "").toUpperCase();
-  if (a.includes("INSERT") || a.includes("CREATE")) {
+  if (a.includes("CREATED") || a.includes("CREATE") || a.includes("APPROVED")) {
     return (
       <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-bold border-success/40 bg-success/10 text-success">
         <Plus size={11} />
@@ -60,7 +64,12 @@ function ActionBadge({ action }: { action: string | null | undefined }) {
       </span>
     );
   }
-  if (a.includes("UPDATE") || a.includes("EDIT")) {
+  if (
+    a.includes("UPDATE") ||
+    a.includes("EDIT") ||
+    a.includes("RESULT") ||
+    a.includes("ATTENDANCE")
+  ) {
     return (
       <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-bold border-alert/40 bg-alert/10 text-alert">
         <Filter size={11} />
@@ -85,8 +94,15 @@ function ActionBadge({ action }: { action: string | null | undefined }) {
 
 function rowAccent(action: string | null | undefined): string {
   const a = (action ?? "").toUpperCase();
-  if (a.includes("INSERT") || a.includes("CREATE")) return "border-l-success";
-  if (a.includes("UPDATE") || a.includes("EDIT")) return "border-l-alert";
+  if (a.includes("CREATED") || a.includes("CREATE") || a.includes("APPROVED"))
+    return "border-l-success";
+  if (
+    a.includes("UPDATE") ||
+    a.includes("EDIT") ||
+    a.includes("RESULT") ||
+    a.includes("ATTENDANCE")
+  )
+    return "border-l-alert";
   if (a.includes("DELETE")) return "border-l-error";
   return "border-l-border-default";
 }
@@ -112,7 +128,7 @@ export default function AuditLog() {
     async function load() {
       setLoading(true);
       try {
-        const data = await fetchFullAuditLog(500);
+        const data = await fetchStructuredAuditLog(500);
         if (mounted) setRecords(data);
       } catch (error) {
         console.error(error);
@@ -137,12 +153,12 @@ export default function AuditLog() {
         return false;
       if (
         filterAction &&
-        !r.action?.toLowerCase().includes(filterAction.toLowerCase())
+        !r.audit_code?.toLowerCase().includes(filterAction.toLowerCase())
       )
         return false;
       if (
         filterModule &&
-        !r.entity?.toLowerCase().includes(filterModule.toLowerCase())
+        !r.audit_group?.toLowerCase().includes(filterModule.toLowerCase())
       )
         return false;
       return true;
@@ -157,7 +173,8 @@ export default function AuditLog() {
 
   const statsDelete = useMemo(
     () =>
-      records.filter((r) => r.action?.toUpperCase().includes("DELETE")).length,
+      records.filter((r) => r.audit_code?.toUpperCase().includes("DELETE"))
+        .length,
     [records],
   );
   const uniqueUsers = useMemo(
@@ -268,7 +285,7 @@ export default function AuditLog() {
                 }}
               >
                 <option value="">Todos os Tipos</option>
-                {Array.from(new Set(records.map((r) => r.action)))
+                {Array.from(new Set(records.map((r) => r.audit_code)))
                   .filter(Boolean)
                   .map((a) => (
                     <option key={a} value={a!}>
@@ -291,7 +308,7 @@ export default function AuditLog() {
                 }}
               >
                 <option value="">Todos os Módulos</option>
-                {Array.from(new Set(records.map((r) => r.entity)))
+                {Array.from(new Set(records.map((r) => r.audit_group)))
                   .filter(Boolean)
                   .map((m) => (
                     <option key={m} value={m!}>
@@ -339,7 +356,7 @@ export default function AuditLog() {
                         )}
                       </p>
                     </div>
-                    <ActionBadge action={r.action} />
+                    <ActionBadge action={r.audit_code} />
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="h-9 w-9 rounded-full bg-primary/10 text-primary font-bold text-xs flex items-center justify-center">
@@ -353,7 +370,7 @@ export default function AuditLog() {
                         {r.user_name ?? "—"}
                       </span>
                       <span className="text-xs text-text-muted">
-                        {r.entity ?? "—"}
+                        {r.summary ?? r.entity ?? "—"}
                       </span>
                     </div>
                   </div>
@@ -362,9 +379,9 @@ export default function AuditLog() {
                       <span className="font-semibold text-text-muted uppercase tracking-widest block text-[10px]">
                         IP
                       </span>
-                      {extractIp(r.details)}
+                      {extractIp(r)}
                     </div>
-                    {r.details && (
+                    {(r.details_text || r.details_json) && (
                       <button
                         type="button"
                         className="inline-flex items-center gap-1.5 text-xs font-bold text-primary hover:text-secondary bg-primary/5 hover:bg-primary/10 px-3 py-1.5 rounded-md transition-colors"
@@ -437,23 +454,23 @@ export default function AuditLog() {
                       </td>
 
                       <td className="px-5 py-4">
-                        <ActionBadge action={r.action} />
+                        <ActionBadge action={r.audit_code} />
                       </td>
 
                       <td className="px-5 py-4">
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-bg-default text-text-body">
-                          {r.entity ?? "—"}
+                          {r.audit_group ?? r.entity ?? "—"}
                         </span>
                       </td>
 
                       <td className="px-5 py-4">
                         <span className="text-xs font-mono text-text-muted">
-                          {extractIp(r.details)}
+                          {extractIp(r)}
                         </span>
                       </td>
 
                       <td className="px-5 py-4 text-right">
-                        {r.details && (
+                        {(r.details_text || r.details_json) && (
                           <button
                             type="button"
                             className="inline-flex items-center gap-1.5 text-xs font-bold text-primary hover:text-secondary bg-primary/5 hover:bg-primary/10 px-3 py-1.5 rounded-md transition-colors"
@@ -571,7 +588,8 @@ export default function AuditLog() {
                     Detalhes da Alteração
                   </h4>
                   <p className="text-xs text-text-muted mt-0.5 font-mono">
-                    {detailRecord.action} · {detailRecord.entity} ·{" "}
+                    {detailRecord.audit_code ?? detailRecord.action} ·{" "}
+                    {detailRecord.audit_group ?? detailRecord.entity} ·{" "}
                     {detailRecord.user_name}
                   </p>
                 </div>
@@ -585,7 +603,7 @@ export default function AuditLog() {
                 </button>
               </div>
               <pre className="p-6 overflow-auto max-h-[70vh] text-xs font-mono text-text-body bg-bg-default">
-                {formatJson(detailRecord.details ?? "")}
+                {formatJson(getDetailsPreview(detailRecord))}
               </pre>
             </div>
           </div>

--- a/src/pages/SessionBookingsManagement.tsx
+++ b/src/pages/SessionBookingsManagement.tsx
@@ -53,18 +53,6 @@ type SessionInfo = {
 
 type DisplayStatus = BookingRow["status"] | "confirmado";
 
-const _STATUS_LABELS: Record<BookingRow["status"], string> = {
-  agendado: "Agendado",
-  remarcado: "Remarcado",
-  cancelado: "Cancelado",
-};
-
-const _STATUS_CLASSES: Record<BookingRow["status"], string> = {
-  agendado: "border-success/40 bg-success/10 text-success",
-  remarcado: "border-alert/40 bg-alert/10 text-alert",
-  cancelado: "bg-bg-default text-text-muted",
-};
-
 const DISPLAY_STATUS_LABELS: Record<DisplayStatus, string> = {
   agendado: "Agendado",
   remarcado: "Remarcado",

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -461,6 +461,24 @@ export interface Database {
           created_at?: string | null;
         }[];
       };
+      get_audit_logs_structured: {
+        Args: { p_limit?: number | null };
+        Returns: {
+          id: string;
+          action: string | null;
+          entity: string | null;
+          user_id: string | null;
+          user_name: string | null;
+          created_at: string | null;
+          details_text: string | null;
+          details_json: Json | null;
+          ip_address: string | null;
+          audit_code: string | null;
+          audit_group: string | null;
+          target_id: string | null;
+          summary: string | null;
+        }[];
+      };
       approve_swap: {
         Args: { p_request_id: string; p_admin_id: string };
         Returns: { success: boolean; error: string }[];

--- a/supabase/rpc/20260402_get_audit_logs_structured.sql
+++ b/supabase/rpc/20260402_get_audit_logs_structured.sql
@@ -1,0 +1,123 @@
+create or replace function public.try_parse_audit_details_json(
+  p_text text
+)
+returns jsonb
+language plpgsql
+immutable
+as $$
+begin
+  if p_text is null or btrim(p_text) = '' then
+    return '{}'::jsonb;
+  end if;
+
+  return p_text::jsonb;
+exception
+  when others then
+    return jsonb_build_object('raw', p_text);
+end;
+$$;
+
+create or replace function public.get_audit_logs_structured(
+  p_limit integer default 500
+)
+returns table (
+  id uuid,
+  action text,
+  entity text,
+  user_id uuid,
+  user_name text,
+  created_at timestamptz,
+  details_text text,
+  details_json jsonb,
+  ip_address text,
+  audit_code text,
+  audit_group text,
+  target_id text,
+  summary text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with normalized as (
+    select
+      al.id,
+      al.action,
+      al.entity,
+      al.user_id,
+      al.user_name,
+      al.created_at,
+      al.details as details_text,
+      case
+        when al.details is null or btrim(al.details) = '' then '{}'::jsonb
+        when left(ltrim(al.details), 1) in ('{', '[') then public.try_parse_audit_details_json(al.details)
+        else coalesce(
+          (
+            select jsonb_object_agg(
+              trim(split_part(part, '=', 1)),
+              to_jsonb(nullif(trim(split_part(part, '=', 2)), ''))
+            )
+            from unnest(string_to_array(al.details, ';')) as part
+            where trim(part) <> ''
+              and trim(split_part(part, '=', 1)) <> ''
+          ),
+          jsonb_build_object('raw', al.details)
+        )
+      end as details_json
+    from public.audit_logs al
+    order by al.created_at desc
+    limit greatest(coalesce(p_limit, 500), 1)
+  )
+  select
+    n.id,
+    n.action,
+    n.entity,
+    n.user_id,
+    n.user_name,
+    n.created_at,
+    n.details_text,
+    n.details_json,
+    coalesce(n.details_json ->> 'ip', n.details_json ->> 'ip_address', '-') as ip_address,
+    case
+      when lower(coalesce(n.entity, '')) = 'session' and lower(coalesce(n.action, '')) = 'create' then 'SESSION_CREATED'
+      when lower(coalesce(n.entity, '')) = 'booking' and n.details_text ilike '%attendance_confirmed=%' then 'ATTENDANCE_UPDATED'
+      when lower(coalesce(n.entity, '')) = 'booking' and n.details_text ilike '%result_details=%' then 'RESULT_SET'
+      when lower(coalesce(n.entity, '')) = 'swap_request' and lower(coalesce(n.action, '')) = 'create' then 'SWAP_REQUEST_CREATED'
+      when lower(coalesce(n.entity, '')) = 'session' and (
+        lower(coalesce(n.action, '')) like '%close%'
+        or n.details_text ilike '%closure%'
+        or n.details_text ilike '%session_closed%'
+      ) then 'SESSION_CLOSED'
+      else upper(concat_ws('_', coalesce(n.action, 'unknown'), coalesce(n.entity, 'system')))
+    end as audit_code,
+    case
+      when lower(coalesce(n.entity, '')) = 'session' then 'turmas'
+      when lower(coalesce(n.entity, '')) = 'booking' then 'agendamentos'
+      when lower(coalesce(n.entity, '')) = 'swap_request' then 'reagendamentos'
+      else coalesce(lower(n.entity), 'sistema')
+    end as audit_group,
+    coalesce(
+      n.details_json ->> 'session_id',
+      n.details_json ->> 'booking_id',
+      n.details_json ->> 'swap_request_id',
+      n.details_json ->> 'id'
+    ) as target_id,
+    case
+      when lower(coalesce(n.entity, '')) = 'session' and lower(coalesce(n.action, '')) = 'create' then 'Turma criada'
+      when lower(coalesce(n.entity, '')) = 'booking' and n.details_text ilike '%attendance_confirmed=true%' then 'Presença confirmada'
+      when lower(coalesce(n.entity, '')) = 'booking' and n.details_text ilike '%attendance_confirmed=false%' then 'Presença removida'
+      when lower(coalesce(n.entity, '')) = 'booking' and n.details_text ilike '%result_details=%' then 'Resultado registrado'
+      when lower(coalesce(n.entity, '')) = 'swap_request' and lower(coalesce(n.action, '')) = 'create' then 'Solicitação de reagendamento criada'
+      when lower(coalesce(n.entity, '')) = 'session' and (
+        lower(coalesce(n.action, '')) like '%close%'
+        or n.details_text ilike '%closure%'
+        or n.details_text ilike '%session_closed%'
+      ) then 'Sessão encerrada'
+      else initcap(replace(coalesce(n.action, 'evento'), '_', ' '))
+    end as summary
+  from normalized n
+  order by n.created_at desc;
+$$;
+
+comment on function public.get_audit_logs_structured(integer) is
+'Retorna auditoria normalizada com taxonomia, detalhes JSON e resumo legível para UI administrativa.';


### PR DESCRIPTION
## Objetivo
Sprint 3 do roadmap de otimização do ciclo de sessões: estruturar a auditoria administrativa sem depender de merge das PRs anteriores.

## O que muda
- Adiciona a RPC `get_audit_logs_structured(p_limit)` para normalizar o histórico de auditoria.
- Classifica eventos em códigos estáveis como `SESSION_CREATED`, `ATTENDANCE_UPDATED`, `RESULT_SET`, `SWAP_REQUEST_CREATED` e `SESSION_CLOSED`.
- Converte `details` em `details_json`, extrai `ip_address`, `target_id`, `audit_group` e `summary` legível para a UI.
- Atualiza `fetchStructuredAuditLog` em `src/hooks/useSystemSettings.ts`.
- Refatora `src/pages/AuditLog.tsx` para consumir a taxonomia normalizada sem depender de parsing frágil no cliente.
- Remove constantes mortas em `src/pages/SessionBookingsManagement.tsx` para manter a branch buildável a partir da `main`.

## Impacto
- A tela de auditoria deixa de operar só com texto livre e passa a usar uma taxonomia consistente para filtros, badges e detalhes.
- A normalização fica centralizada no banco, reduzindo lógica duplicada no frontend.
- Mantém compatibilidade com registros legados em `audit_logs` usando heurística de parsing para JSON ou `chave=valor`.

## Validação
- `npx tsc --noEmit` ✅
- `yarn build` ✅

## Observações
- Esta PR não faz merge de nenhuma sprint anterior.
- As PRs já abertas permanecem independentes:
  - Sprint 1: #19
  - Sprint 2: #20
