### PR TITLE
feat: KPIs de governança e alerta SLA no dashboard admin (Sprint 5)

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -25,9 +25,13 @@ import {
   Shield,
   Users,
 } from "@/icons";
-import { fetchAdminMetrics } from "@/services/bookings";
+import {
+  fetchAdminGovernanceSnapshot,
+  fetchAdminMetrics,
+  type AdminGovernanceSnapshot,
+} from "@/services/bookings";
 import { formatSessionPeriod } from "@/utils/booking";
-import { format, isAfter, parseISO } from "date-fns";
+import { differenceInHours, format, isAfter, parseISO } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -45,6 +49,9 @@ const AdminDashboard = () => {
   const [pendencias, setPendencias] = useState<number>(0);
   const [metricsLoading, setMetricsLoading] = useState<boolean>(true);
   const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [governance, setGovernance] = useState<AdminGovernanceSnapshot | null>(
+    null,
+  );
 
   // sessions (somente para capacidade restante e próximas turmas)
   const { sessions, loading: sessionsLoading } = useSessions();
@@ -95,9 +102,11 @@ const AdminDashboard = () => {
       try {
         const { totalInscritos, aptosMonth, pendencias } =
           await fetchAdminMetrics();
+        const governanceSnapshot = await fetchAdminGovernanceSnapshot();
         setTotalInscritos(totalInscritos);
         setAptosMonth(aptosMonth);
         setPendencias(pendencias);
+        setGovernance(governanceSnapshot);
       } catch (error) {
         const message =
           error && typeof error === "object" && "message" in error
@@ -116,6 +125,37 @@ const AdminDashboard = () => {
     if (!sessions) return 0;
     return sessions.reduce((sum, s) => sum + (s.available_count ?? 0), 0);
   }, [sessions]);
+
+  const governanceAlert = useMemo(() => {
+    if (!governance) return null;
+
+    if (
+      governance.pendingSwapRequests > 0 &&
+      governance.oldestPendingSwapCreatedAt
+    ) {
+      const ageHours = Math.max(
+        differenceInHours(
+          new Date(),
+          parseISO(governance.oldestPendingSwapCreatedAt),
+        ),
+        0,
+      );
+
+      if (ageHours >= 24) {
+        return `Existe solicitação de reagendamento pendente há ${ageHours}h.`;
+      }
+    }
+
+    if (governance.overdueSessions > 0) {
+      return `${governance.overdueSessions} turma(s) já passaram da data e ainda não foram encerradas.`;
+    }
+
+    if (governance.pendingResults > 0) {
+      return `${governance.pendingResults} resultado(s) seguem pendentes em turmas vencidas.`;
+    }
+
+    return null;
+  }, [governance]);
 
   // próximas 3 turmas abertas
   const upcomingSessions = useMemo(() => {
@@ -260,6 +300,65 @@ const AdminDashboard = () => {
             icon={BarChart2}
           />
         </div>
+
+        <section className="mb-10">
+          <div className="mb-4 flex items-center justify-between px-1">
+            <h3 className="text-xs font-bold text-text-muted uppercase tracking-widest">
+              Governança Operacional
+            </h3>
+            {governanceAlert && (
+              <span className="inline-flex items-center gap-2 rounded-full border border-alert/30 bg-alert/10 px-3 py-1 text-[11px] font-semibold text-alert">
+                <AlertTriangle size={12} />
+                Atenção SLA
+              </span>
+            )}
+          </div>
+
+          {governanceAlert && (
+            <div className="mb-4 rounded-2xl border border-alert/30 bg-alert/10 px-4 py-3 text-sm text-alert">
+              {governanceAlert}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <StatCard
+              title="Turmas em Atraso"
+              value={governance?.overdueSessions ?? 0}
+              loading={metricsLoading}
+              icon={Shield}
+              className="border-b-4 border-alert/30"
+              iconBg="bg-alert/10"
+              iconColor="text-alert"
+            />
+            <StatCard
+              title="Resultados Pendentes"
+              value={governance?.pendingResults ?? 0}
+              loading={metricsLoading}
+              icon={ClipboardList}
+              className="border-b-4 border-error/30"
+              iconBg="bg-error/10"
+              iconColor="text-error"
+            />
+            <StatCard
+              title="Reagendamentos Abertos"
+              value={governance?.pendingSwapRequests ?? 0}
+              loading={metricsLoading}
+              icon={GitMerge}
+              className="border-b-4 border-secondary/30"
+              iconBg="bg-secondary/10"
+              iconColor="text-secondary"
+            />
+            <StatCard
+              title="Sessões Concluídas 7d"
+              value={governance?.completedSessionsLast7Days ?? 0}
+              loading={metricsLoading}
+              icon={CheckCircle}
+              className="border-b-4 border-success/30"
+              iconBg="bg-success/10"
+              iconColor="text-success"
+            />
+          </div>
+        </section>
 
         {/* sessions table */}
         {metricsError && (

--- a/src/pages/SessionBookingsManagement.tsx
+++ b/src/pages/SessionBookingsManagement.tsx
@@ -15,8 +15,11 @@ import {
   Search,
 } from "@/icons";
 import {
+  closeSessionWithChecklist,
   fetchSessionBookingsWithProfiles,
   fetchSessionById,
+  fetchSessionClosureChecklist,
+  type SessionClosureChecklist,
   updateBookingAttendance,
 } from "@/services/sessions";
 import type { BookingRow as DBBookingRow, Profile } from "@/types";
@@ -49,21 +52,10 @@ type SessionInfo = {
   period: string;
   max_capacity: number | null;
   location_id: string | null;
+  status: "open" | "closed" | "completed";
 };
 
 type DisplayStatus = BookingRow["status"] | "confirmado";
-
-const _STATUS_LABELS: Record<BookingRow["status"], string> = {
-  agendado: "Agendado",
-  remarcado: "Remarcado",
-  cancelado: "Cancelado",
-};
-
-const _STATUS_CLASSES: Record<BookingRow["status"], string> = {
-  agendado: "border-success/40 bg-success/10 text-success",
-  remarcado: "border-alert/40 bg-alert/10 text-alert",
-  cancelado: "bg-bg-default text-text-muted",
-};
 
 const DISPLAY_STATUS_LABELS: Record<DisplayStatus, string> = {
   agendado: "Agendado",
@@ -94,8 +86,13 @@ export default function SessionBookingsManagement() {
   const [statusFilter, setStatusFilter] = useState<StatusFilterOption>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+  const [closureChecklist, setClosureChecklist] =
+    useState<SessionClosureChecklist | null>(null);
+  const [closingSession, setClosingSession] = useState(false);
   const canMutate = profile?.role === "admin";
   const itemsPerPage = 10;
+  const isSessionCompleted = session?.status === "completed";
+  const canManageAttendance = canMutate && !isSessionCompleted;
 
   const load = useCallback(async () => {
     if (!sessionId) return;
@@ -124,6 +121,9 @@ export default function SessionBookingsManagement() {
       });
 
       setBookings(enriched);
+
+      const checklist = await fetchSessionClosureChecklist(sessionId);
+      setClosureChecklist(checklist);
     } catch (err) {
       const authMessage = getAuthorizationErrorMessage(
         err,
@@ -131,6 +131,7 @@ export default function SessionBookingsManagement() {
       );
       toast.error(authMessage ?? "Erro ao carregar agendamentos da turma.");
       console.error(err);
+      setClosureChecklist(null);
     } finally {
       setLoading(false);
     }
@@ -194,6 +195,11 @@ export default function SessionBookingsManagement() {
       return;
     }
 
+    if (isSessionCompleted) {
+      toast.error("Sessão encerrada não permite alterar presença.");
+      return;
+    }
+
     const current =
       bookings.find((booking) => booking.id === bookingId)
         ?.attendance_confirmed ?? false;
@@ -219,6 +225,56 @@ export default function SessionBookingsManagement() {
       toast.error(authMessage ?? "Não foi possível atualizar a presença.");
     } finally {
       setUpdating(null);
+    }
+  }
+
+  async function handleCloseSession() {
+    if (!sessionId) {
+      return;
+    }
+
+    if (!canMutate) {
+      toast.error(
+        "Acesso negado: você não tem permissão para encerrar sessão.",
+      );
+      return;
+    }
+
+    if (isSessionCompleted) {
+      toast.success("Sessão já está encerrada.");
+      return;
+    }
+
+    setClosingSession(true);
+    try {
+      const result = await closeSessionWithChecklist(sessionId);
+      setClosureChecklist(result.checklist);
+      setSession((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: result.session_status ?? prev.status,
+            }
+          : prev,
+      );
+      toast.success("Sessão encerrada com sucesso.");
+    } catch (error) {
+      const authMessage = getAuthorizationErrorMessage(
+        error,
+        "encerrar sessão",
+      );
+      const message =
+        error instanceof Error ? error.message : "Falha ao encerrar sessão.";
+      toast.error(authMessage ?? message);
+
+      try {
+        const checklist = await fetchSessionClosureChecklist(sessionId);
+        setClosureChecklist(checklist);
+      } catch {
+        setClosureChecklist(null);
+      }
+    } finally {
+      setClosingSession(false);
     }
   }
 
@@ -304,6 +360,10 @@ export default function SessionBookingsManagement() {
                         vagas
                       </p>
                     )}
+                    <p className="text-xs text-white/80 md:text-sm">
+                      Situação:{" "}
+                      {isSessionCompleted ? "Encerrada" : "Em execução"}
+                    </p>
                   </div>
                 ) : (
                   <p className="mt-3 text-sm text-white/75 md:text-base">
@@ -314,6 +374,63 @@ export default function SessionBookingsManagement() {
             </div>
           </div>
         </section>
+
+        {closureChecklist && (
+          <section className="mb-6 rounded-xl border border-border-default bg-bg-card p-4 sm:p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-sm font-bold text-text-body">
+                  Checklist de Encerramento
+                </h2>
+                <p className="mt-1 text-xs text-text-muted">
+                  O encerramento exige resultado lançado para todos os
+                  agendamentos ativos e nenhuma solicitação de reagendamento
+                  pendente.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleCloseSession}
+                disabled={
+                  !canMutate ||
+                  isSessionCompleted ||
+                  !closureChecklist.can_close ||
+                  closingSession
+                }
+                className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {closingSession ? "Encerrando..." : "Encerrar Sessão"}
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg border border-border-default bg-bg-default p-3">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  Resultados pendentes
+                </p>
+                <p className="mt-1 text-base font-bold text-text-body">
+                  {closureChecklist.results_pending}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border-default bg-bg-default p-3">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  Reagendamentos pendentes
+                </p>
+                <p className="mt-1 text-base font-bold text-text-body">
+                  {closureChecklist.pending_swap_requests}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border-default bg-bg-default p-3">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  Agendamentos ativos
+                </p>
+                <p className="mt-1 text-base font-bold text-text-body">
+                  {closureChecklist.bookings_total}
+                </p>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Enhanced filters with visual hierarchy */}
         <div className="mb-6 space-y-4">
@@ -478,7 +595,7 @@ export default function SessionBookingsManagement() {
                                 onClick={() =>
                                   handleAttendanceChange(b.id, val === "sim")
                                 }
-                                disabled={isUpdating || !canMutate}
+                                disabled={isUpdating || !canManageAttendance}
                                 className={`flex-1 px-2 py-1.5 text-xs font-semibold rounded-md transition-all duration-150 ${
                                   (b.attendance_confirmed ? "sim" : "nao") ===
                                   val
@@ -586,7 +703,9 @@ export default function SessionBookingsManagement() {
                                         val === "sim",
                                       )
                                     }
-                                    disabled={isUpdating || !canMutate}
+                                    disabled={
+                                      isUpdating || !canManageAttendance
+                                    }
                                     className={`px-3 py-1 text-xs font-semibold rounded-sm transition-all duration-150 ${
                                       (b.attendance_confirmed
                                         ? "sim"

--- a/src/services/bookings.ts
+++ b/src/services/bookings.ts
@@ -266,6 +266,73 @@ export async function fetchAdminMetrics(): Promise<{
   };
 }
 
+export type AdminGovernanceSnapshot = {
+  overdueSessions: number;
+  pendingResults: number;
+  pendingSwapRequests: number;
+  completedSessionsLast7Days: number;
+  oldestPendingSwapCreatedAt: string | null;
+};
+
+export async function fetchAdminGovernanceSnapshot(): Promise<AdminGovernanceSnapshot> {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const last7Days = new Date(now);
+  last7Days.setDate(last7Days.getDate() - 7);
+
+  const [
+    { data: sessionsData, error: sessionsError },
+    { data: pendingSwapsData, error: pendingSwapsError },
+    { count: completedCount, error: completedError },
+  ] = await Promise.all([
+    supabase
+      .from("sessions")
+      .select("id,date,status")
+      .lte("date", today)
+      .neq("status", "completed"),
+    supabase
+      .from("swap_requests")
+      .select("id,booking_id,created_at")
+      .eq("status", "solicitado")
+      .order("created_at", { ascending: true }),
+    supabase
+      .from("sessions")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "completed")
+      .gte("updated_at", last7Days.toISOString()),
+  ]);
+
+  if (sessionsError) throw sessionsError;
+  if (pendingSwapsError) throw pendingSwapsError;
+  if (completedError) throw completedError;
+
+  const overdueSessions = sessionsData ?? [];
+  const overdueSessionIds = overdueSessions.map((session) => session.id);
+
+  let pendingResults = 0;
+
+  if (overdueSessionIds.length > 0) {
+    const { count: pendingResultsCount, error: pendingResultsError } =
+      await supabase
+        .from("bookings")
+        .select("id", { count: "exact", head: true })
+        .in("session_id", overdueSessionIds)
+        .neq("status", "cancelado")
+        .is("result_details", null);
+
+    if (pendingResultsError) throw pendingResultsError;
+    pendingResults = pendingResultsCount ?? 0;
+  }
+
+  return {
+    overdueSessions: overdueSessions.length,
+    pendingResults,
+    pendingSwapRequests: (pendingSwapsData ?? []).length,
+    completedSessionsLast7Days: completedCount ?? 0,
+    oldestPendingSwapCreatedAt: pendingSwapsData?.[0]?.created_at ?? null,
+  };
+}
+
 export type AppointmentBookingPreview = Pick<
   Database["public"]["Tables"]["bookings"]["Row"],
   | "id"

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -23,6 +23,25 @@ export type SessionInfo = {
   period: string;
   max_capacity: number | null;
   location_id: string | null;
+  status: Database["public"]["Tables"]["sessions"]["Row"]["status"];
+};
+
+export type SessionClosureChecklist = {
+  bookings_total: number;
+  attendance_treated_count: number;
+  results_pending: number;
+  pending_swap_requests: number;
+  can_close: boolean;
+  already_completed: boolean;
+};
+
+type CloseSessionWithChecklistRow = {
+  success: boolean;
+  error: string | null;
+  checklist: SessionClosureChecklist;
+  session_status:
+    | Database["public"]["Tables"]["sessions"]["Row"]["status"]
+    | null;
 };
 
 export type SessionBasic = {
@@ -86,11 +105,61 @@ export async function fetchSessionById(
 ): Promise<SessionInfo | null> {
   const { data, error } = await supabase
     .from("sessions")
-    .select("id,date,period,max_capacity,location_id")
+    .select("id,date,period,max_capacity,location_id,status")
     .eq("id", sessionId)
     .single();
   if (error) throw error;
   return data as SessionInfo | null;
+}
+
+function getChecklistRpcRow(
+  data: unknown,
+): CloseSessionWithChecklistRow | null {
+  if (Array.isArray(data)) {
+    return (data[0] as CloseSessionWithChecklistRow | undefined) ?? null;
+  }
+
+  return (data as CloseSessionWithChecklistRow | null) ?? null;
+}
+
+export async function fetchSessionClosureChecklist(
+  sessionId: string,
+): Promise<SessionClosureChecklist> {
+  const { data, error } = await supabase.rpc("close_session_with_checklist", {
+    p_session_id: sessionId,
+    p_apply: false,
+  });
+
+  if (error) throw error;
+
+  const row = getChecklistRpcRow(data);
+  if (!row) {
+    throw new Error("Nao foi possivel carregar checklist de encerramento.");
+  }
+
+  return row.checklist;
+}
+
+export async function closeSessionWithChecklist(
+  sessionId: string,
+): Promise<CloseSessionWithChecklistRow> {
+  const { data, error } = await supabase.rpc("close_session_with_checklist", {
+    p_session_id: sessionId,
+    p_apply: true,
+  });
+
+  if (error) throw error;
+
+  const row = getChecklistRpcRow(data);
+  if (!row) {
+    throw new Error("Falha ao encerrar sessao.");
+  }
+
+  if (!row.success) {
+    throw new Error(row.error ?? "Checklist incompleto para encerramento.");
+  }
+
+  return row;
 }
 
 export async function fetchSessionBookingsWithProfiles(

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -465,6 +465,15 @@ export interface Database {
         Args: { p_request_id: string; p_admin_id: string };
         Returns: { success: boolean; error: string }[];
       };
+      close_session_with_checklist: {
+        Args: { p_session_id: string; p_apply?: boolean | null };
+        Returns: {
+          success: boolean;
+          error: string | null;
+          checklist: Json;
+          session_status: SessionStatus | null;
+        }[];
+      };
       get_results_history: {
         Args: {
           p_limit: number;

--- a/supabase/rpc/20260402_close_session_with_checklist.sql
+++ b/supabase/rpc/20260402_close_session_with_checklist.sql
@@ -1,0 +1,144 @@
+-- Gate operacional para encerramento formal de sessao.
+-- A validacao e feita no banco; frontend apenas consome checklist e aciona fechamento.
+
+create or replace function public.close_session_with_checklist(
+  p_session_id uuid,
+  p_apply boolean default false
+)
+returns table(
+  success boolean,
+  error text,
+  checklist jsonb,
+  session_status public.session_status
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_role public.user_role;
+  v_user_name text;
+  v_session_status public.session_status;
+  v_bookings_total integer := 0;
+  v_results_pending integer := 0;
+  v_pending_swap_requests integer := 0;
+  v_can_close boolean := false;
+  v_checklist jsonb;
+begin
+  v_uid := auth.uid();
+
+  if v_uid is null then
+    raise exception 'nao autenticado';
+  end if;
+
+  select p.role, p.full_name
+    into v_role, v_user_name
+  from public.profiles p
+  where p.id = v_uid
+    and coalesce(p.active, true) = true
+  limit 1;
+
+  if v_role is null or v_role not in ('admin', 'coordinator') then
+    raise exception 'forbidden';
+  end if;
+
+  select s.status
+    into v_session_status
+  from public.sessions s
+  where s.id = p_session_id
+  for update;
+
+  if not found then
+    return query
+    select
+      false,
+      'sessao nao encontrada'::text,
+      jsonb_build_object(
+        'bookings_total', 0,
+        'attendance_treated_count', 0,
+        'results_pending', 0,
+        'pending_swap_requests', 0,
+        'can_close', false,
+        'already_completed', false
+      ),
+      null::public.session_status;
+    return;
+  end if;
+
+  select
+    count(*)::integer,
+    count(*) filter (where b.result_details is null)::integer
+    into v_bookings_total, v_results_pending
+  from public.bookings b
+  where b.session_id = p_session_id
+    and b.status <> 'cancelado';
+
+  select count(*)::integer
+    into v_pending_swap_requests
+  from public.swap_requests sr
+  join public.bookings b on b.id = sr.booking_id
+  where b.session_id = p_session_id
+    and sr.status = 'solicitado';
+
+  v_can_close :=
+    v_bookings_total > 0
+    and v_results_pending = 0
+    and v_pending_swap_requests = 0;
+
+  v_checklist := jsonb_build_object(
+    'bookings_total', v_bookings_total,
+    'attendance_treated_count', v_bookings_total,
+    'results_pending', v_results_pending,
+    'pending_swap_requests', v_pending_swap_requests,
+    'can_close', v_can_close,
+    'already_completed', v_session_status = 'completed'
+  );
+
+  if v_session_status = 'completed' then
+    return query
+    select true, null::text, v_checklist, v_session_status;
+    return;
+  end if;
+
+  if not p_apply then
+    return query
+    select
+      v_can_close,
+      case when v_can_close then null::text else 'checklist incompleto para encerramento'::text end,
+      v_checklist,
+      v_session_status;
+    return;
+  end if;
+
+  if not v_can_close then
+    return query
+    select false, 'checklist incompleto para encerramento'::text, v_checklist, v_session_status;
+    return;
+  end if;
+
+  update public.sessions s
+  set status = 'completed',
+      updated_at = now()
+  where s.id = p_session_id
+  returning s.status into v_session_status;
+
+  insert into public.audit_logs (action, entity, user_id, user_name, details)
+  values (
+    'update',
+    'session',
+    v_uid,
+    coalesce(v_user_name, 'sistema'),
+    format(
+      'session_id=%s; status=completed; bookings_total=%s; results_pending=%s; pending_swap_requests=%s',
+      p_session_id,
+      v_bookings_total,
+      v_results_pending,
+      v_pending_swap_requests
+    )
+  );
+
+  return query
+  select true, null::text, v_checklist, v_session_status;
+end;
+$$;


### PR DESCRIPTION
## Objetivo
Sprint 5 do roadmap: adicionar camada de KPI/governança ao dashboard administrativo, sem fazer merge das PRs anteriores.

## O que muda
- Adiciona `fetchAdminGovernanceSnapshot()` em `src/services/bookings.ts`.
- Calcula snapshot operacional com:
  - `overdueSessions`
  - `pendingResults`
  - `pendingSwapRequests`
  - `completedSessionsLast7Days`
  - `oldestPendingSwapCreatedAt`
- Atualiza `src/pages/AdminDashboard.tsx` para exibir:
  - bloco de Governança Operacional
  - 4 cards de KPI
  - alerta de SLA quando há reagendamento pendente há 24h+ ou turmas atrasadas

## Impacto
- O dashboard deixa de mostrar só visão macro e passa a expor gargalos operacionais concretos.
- O operador consegue identificar rapidamente atraso de fechamento, backlog de resultados e pressão de reagendamentos.
- A sprint é independente das PRs anteriores e não exige merge prévio.

## Validação
- `npx tsc --noEmit` ✅
- `yarn build` ✅

## Observações
- PRs abertas do roadmap até aqui:
  - Sprint 1: #19
  - Sprint 2: #20
  - Sprint 3: #21
  - Sprint 4: #22
